### PR TITLE
Add missed_deadlines filter for dag runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -55,6 +55,7 @@ from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import TaskInstance
+from airflow.models.deadline import Deadline
 from airflow.models.variable import Variable
 from airflow.typing_compat import Self
 from airflow.utils import timezone
@@ -598,6 +599,29 @@ QueryDagRunRunTypesFilter = Annotated[
             transform_callable=_transform_dag_run_types,
         )
     ),
+]
+
+
+class _MissedDeadlinesFilter(BaseParam[bool]):
+    """Filter dag runs that missed their deadline."""
+
+    def to_orm(self, select: Select) -> Select:
+        if not self.value:
+            return select
+        return (
+            select.join(Deadline, DagRun.id == Deadline.dagrun_id)
+            .where(DagRun.last_scheduling_decision.is_not(None))
+            .where(Deadline.deadline_time < DagRun.last_scheduling_decision)
+        )
+
+    @classmethod
+    def depends(cls, missed_deadlines: bool | None = Query(default=None)) -> _MissedDeadlinesFilter:
+        return cls().set_value(missed_deadlines)
+
+
+QueryDagRunMissedDeadlinesFilter = Annotated[
+    _MissedDeadlinesFilter,
+    Depends(_MissedDeadlinesFilter.depends),
 ]
 
 # DAGTags

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -163,3 +163,4 @@ class DAGRunsBatchBody(StrictBaseModel):
     start_date_lte: AwareDatetime | None = None
     end_date_gte: AwareDatetime | None = None
     end_date_lte: AwareDatetime | None = None
+    missed_deadlines: bool | None = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -2018,6 +2018,12 @@ paths:
             format: date-time
           - type: 'null'
           title: Updated At Lte
+      - name: missed_deadlines
+        in: query
+        required: false
+        schema:
+          type: boolean
+          title: Missed Deadlines
       - name: run_type
         in: query
         required: false
@@ -8794,6 +8800,9 @@ components:
             format: date-time
           - type: 'null'
           title: End Date Lte
+        missed_deadlines:
+          type: boolean
+          title: Missed Deadlines
       additionalProperties: false
       type: object
       title: DAGRunsBatchBody
@@ -10487,6 +10496,9 @@ components:
             format: date-time
           - type: 'null'
           title: End Date Lte
+        missed_deadlines:
+          type: boolean
+          title: Missed Deadlines
         duration_gte:
           anyOf:
           - type: number

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -28,6 +28,7 @@ from sqlalchemy import select
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagModel, DagRun
+from airflow.models.deadline import Deadline
 from airflow.models.asset import AssetEvent, AssetModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.definitions.asset import Asset
@@ -553,6 +554,26 @@ class TestGetDagRuns:
             response.json()["detail"] == f"Invalid value for state. Valid values are {', '.join(DagRunState)}"
         )
 
+    def test_missed_deadlines_filter(self, test_client, dag_maker, session):
+        with dag_maker(dag_id="deadline_dag", serialized=True) as dag:
+            EmptyOperator(task_id="t1")
+        dr = dag_maker.create_dagrun(run_id="deadline_run", logical_date=LOGICAL_DATE1)
+        dr.last_scheduling_decision = LOGICAL_DATE1 + timedelta(hours=2)
+        Deadline.add_deadline(
+            Deadline(
+                deadline_time=dr.last_scheduling_decision - timedelta(hours=1),
+                dag_id=dr.dag_id,
+                dagrun_id=dr.id,
+                callback="print",
+            )
+        )
+        session.commit()
+
+        response = test_client.get(f"/dags/{dr.dag_id}/dagRuns", params={"missed_deadlines": True})
+        assert response.status_code == 200
+        body = response.json()
+        assert [r["dag_run_id"] for r in body["dag_runs"]] == ["deadline_run"]
+
 
 class TestListDagRunsBatch:
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
@@ -878,6 +899,28 @@ class TestListDagRunsBatch:
         response = test_client.post("/dags/~/dagRuns/list", json=post_body)
         assert response.status_code == 422
         assert response.json()["detail"] == expected_response
+
+    def test_missed_deadlines_filter(self, test_client, dag_maker, session):
+        with dag_maker(dag_id="deadline_dag_batch", serialized=True) as dag:
+            EmptyOperator(task_id="t1")
+        dr = dag_maker.create_dagrun(run_id="deadline_run_batch", logical_date=LOGICAL_DATE1)
+        dr.last_scheduling_decision = LOGICAL_DATE1 + timedelta(hours=2)
+        Deadline.add_deadline(
+            Deadline(
+                deadline_time=dr.last_scheduling_decision - timedelta(hours=1),
+                dag_id=dr.dag_id,
+                dagrun_id=dr.id,
+                callback="print",
+            )
+        )
+        session.commit()
+        response = test_client.post(
+            "/dags/~/dagRuns/list",
+            json={"dag_ids": [dr.dag_id], "missed_deadlines": True},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert [r["dag_run_id"] for r in body["dag_runs"]] == ["deadline_run_batch"]
 
 
 class TestPatchDagRun:


### PR DESCRIPTION
## Summary
- add `_MissedDeadlinesFilter` and expose `missed_deadlines` query param
- support the filter for listing DAG runs
- document parameter in OpenAPI spec
- cover new filter in tests